### PR TITLE
Fix missing Nginx rule

### DIFF
--- a/public/nginx.htaccess
+++ b/public/nginx.htaccess
@@ -1,0 +1,5 @@
+location / {
+    if (!-e $request_filename){
+        rewrite  ^(.*)$  /index.php?s=$1  last;   break;
+    }
+}


### PR DESCRIPTION
Nginx.htaccess is an empty file in newest version on the main branch. The site cannot run without the rule.